### PR TITLE
Provide more context when we fail to look up DNS Entries

### DIFF
--- a/common/src/main/java/de/rafael/modflared/mixin/ClientConnectionMixin.java
+++ b/common/src/main/java/de/rafael/modflared/mixin/ClientConnectionMixin.java
@@ -26,7 +26,7 @@ public abstract class ClientConnectionMixin implements TunnelManager.Connection 
 
     @Redirect(method = "connect(Ljava/net/InetSocketAddress;ZLnet/minecraft/util/profiler/PerformanceLog;)Lnet/minecraft/network/ClientConnection;", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;connect(Ljava/net/InetSocketAddress;ZLnet/minecraft/network/ClientConnection;)Lio/netty/channel/ChannelFuture;"))
     private static ChannelFuture connect(@NotNull InetSocketAddress address, boolean useEpoll, ClientConnection connection) {
-        return ClientConnection.connect(Modflared.TUNNEL_MANAGER.handleConnect(address, connection), useEpoll, connection);
+        return ClientConnection.connect(Modflared.TUNNEL_MANAGER.handleConnect(address, connection).address(), useEpoll, connection);
     }
 
     @Inject(method = "disconnect", at = @At("TAIL"))

--- a/common/src/main/java/de/rafael/modflared/mixin/ConnectScreenMixin.java
+++ b/common/src/main/java/de/rafael/modflared/mixin/ConnectScreenMixin.java
@@ -1,21 +1,82 @@
 package de.rafael.modflared.mixin;
 
 import de.rafael.modflared.Modflared;
+import de.rafael.modflared.mixininterfaces.ConnectScreenInterface;
+import de.rafael.modflared.tunnel.manager.TunnelManager;
+import de.rafael.modflared.tunnel.manager.TunnelManager.HandleConnectResult;
 import io.netty.channel.ChannelFuture;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.net.InetSocketAddress;
 
 @Mixin(targets = "net.minecraft.client.gui.screen.multiplayer.ConnectScreen$1")
-public abstract class ConnectScreenMixin implements Runnable {
+abstract class ConnectScreen1Mixin implements Runnable {
 
-    @Redirect(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;connect(Ljava/net/InetSocketAddress;ZLnet/minecraft/network/ClientConnection;)Lio/netty/channel/ChannelFuture;"))
+    @Redirect(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;connect" +
+            "(Ljava/net/InetSocketAddress;ZLnet/minecraft/network/ClientConnection;)Lio/netty/channel/ChannelFuture;"))
     private ChannelFuture connect(@NotNull InetSocketAddress address, boolean useEpoll, ClientConnection connection) {
-        return ClientConnection.connect(Modflared.TUNNEL_MANAGER.handleConnect(address, connection), useEpoll, connection);
+        var handleConnectResult = Modflared.TUNNEL_MANAGER.handleConnect(address, connection);
+
+        var currentScreen =  MinecraftClient.getInstance().currentScreen;
+        if (currentScreen instanceof ConnectScreen connectScreen) {
+            ((ConnectScreenInterface) connectScreen).modflared$setStatus(handleConnectResult);
+        }
+
+
+        return ClientConnection.connect(handleConnectResult.address(), useEpoll, connection);
+    }
+}
+
+@Mixin(targets = "net.minecraft.client.gui.screen.multiplayer.ConnectScreen")
+public abstract class ConnectScreenMixin extends Screen implements ConnectScreenInterface {
+
+
+    protected ConnectScreenMixin(Text title) {
+        super(title);
     }
 
+
+    @Unique
+    @Nullable
+    public TunnelManager.HandleConnectResult modflared$status;
+
+    @Override
+    public void modflared$setStatus(HandleConnectResult status) {
+        this.modflared$status = status;
+    }
+
+    @Shadow
+    private Text status;
+
+    @Inject(method = "render", at = @At("TAIL"))
+    public void render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        // This screen starts drawing before the connection is established, so we need to check if the status is null
+        // We're also checking if the status is the default "Connecting..." status, because we know we've connected to the server
+        // when the status changes
+        if (this.modflared$status == null || !status.equals(Text.translatable("connect.connecting"))) return;
+
+        int y = this.height / 2 - 50;
+        // Connecting Text is drawn at y = this.height / 2 - 50
+        y += 10;
+
+        for (Text status : this.modflared$status.getStatusFeedback()) {
+            y += 10;
+            context.drawCenteredTextWithShadow(this.textRenderer, status, this.width / 2, y, 16777215);
+
+        }
+    }
 }

--- a/common/src/main/java/de/rafael/modflared/mixininterfaces/ConnectScreenInterface.java
+++ b/common/src/main/java/de/rafael/modflared/mixininterfaces/ConnectScreenInterface.java
@@ -1,0 +1,7 @@
+package de.rafael.modflared.mixininterfaces;
+
+import de.rafael.modflared.tunnel.manager.TunnelManager.HandleConnectResult;
+
+public interface ConnectScreenInterface {
+    void modflared$setStatus(HandleConnectResult status);
+}

--- a/common/src/main/resources/modflared-common.mixins.json
+++ b/common/src/main/resources/modflared-common.mixins.json
@@ -7,6 +7,7 @@
   ],
   "mixins": [
     "ClientConnectionMixin",
+    "ConnectScreen1Mixin",
     "ConnectScreenMixin"
   ],
   "injectors": {


### PR DESCRIPTION
I ran into issues using this mod on my Universities Network. For some reason we weren't able to look up the TXT entries and this was preventing us from being able to connect to any servers.

![Screenshot 2024-02-11 200104](https://github.com/HttpRafa/modflared/assets/59785640/2189d1b5-c6cc-4779-b622-10718d96121d)

I've fixed this by catching this error and defaulting to not using a tunnel in this case. I've also added information when this happens to tell the user to use the `forced_tunnels.json` if they need to when this happens

* Fixes being unable to connect to servers regularly when we can't look up DNS entries
  * When we can't look up DNS entries we assume all servers aren't running on cloudflare tunnels.
* Tells the user to use the `forced_tunnels.json` when we can't look up DNS entries to override the above behavior.
* We now tell the user when we're using a tunnel while connecting.

Here are the new screens:
We failed to look up a server's TXT records:
![image](https://github.com/HttpRafa/modflared/assets/59785640/3f43c123-95ce-4e2e-84ce-e09ec44bc332)

We're using a tunnel:
![image](https://github.com/HttpRafa/modflared/assets/59785640/83316c31-3e6e-46e2-a38d-68128844c171)

The additional Information in the logs:
```
[22:35:58] [Server Connector #8/ERROR] (modflared) Modflared was unable to determine if a tunnel should be used for play.dacubeking.com and is defaulting to not using a tunnel
[22:35:58] [Server Connector #8/ERROR] (modflared) If you believe you need a tunnel for this server, please add it to the forced tunnels list in the modflared folder in your game directory.
[22:35:58] [Server Connector #8/ERROR] (modflared) For more information, please see the modflared documentation at https://github.com/HttpRafa/modflared?tab=readme-ov-file#versions-100-and-onward
```
