### PR TITLE
Windows on ARM Compatability

### DIFF
--- a/common/src/main/java/de/rafael/modflared/binary/download/CloudflaredDownload.java
+++ b/common/src/main/java/de/rafael/modflared/binary/download/CloudflaredDownload.java
@@ -12,6 +12,7 @@ public enum CloudflaredDownload {
     LINUX_64("linux", "amd64", "cloudflared-linux-amd64", "cloudflared-linux-amd64"),
     MAC_OS_X_64("mac os x", "x86_64", "cloudflared-darwin-amd64", "cloudflared-darwin-amd64.tgz"),
 
+    WINDOW_ARM("windows", "aarch64", "cloudflared-windows-amd64.exe", "cloudflared-windows-amd64.exe"),
     MAC_OS_ARM("mac os x", "aarch64", "cloudflared-darwin-amd64", "cloudflared-darwin-amd64.tgz");
 
     private final String osName;


### PR DESCRIPTION
Added an entry to the CloudFlared download for Windows on ARM. Still uses the 64 bit cloudflared file but windows automatically will run it through a compatibility layer.