### PR TITLE
Change macOS ARM to Correct Cloudflared Binary

### DIFF
--- a/common/src/main/java/de/rafael/modflared/binary/download/CloudflaredDownload.java
+++ b/common/src/main/java/de/rafael/modflared/binary/download/CloudflaredDownload.java
@@ -13,7 +13,7 @@ public enum CloudflaredDownload {
     MAC_OS_X_64("mac os x", "x86_64", "cloudflared-darwin-amd64", "cloudflared-darwin-amd64.tgz"),
 
     WINDOW_ARM("windows", "aarch64", "cloudflared-windows-amd64.exe", "cloudflared-windows-amd64.exe"),
-    MAC_OS_ARM("mac os x", "aarch64", "cloudflared-darwin-amd64", "cloudflared-darwin-amd64.tgz");
+    MAC_OS_ARM("mac os x", "aarch64", "cloudflared-darwin-arm64", "cloudflared-darwin-arm64.tgz");
 
     private final String osName;
     private final String arch;


### PR DESCRIPTION
Would need to do the same for 1.21.7, but is an easy change. Somehow the MAC_OS_ARM is set to pull the amd64 instead of arm64, which is fixed in this commit