### PR TITLE
chore: Allow 26.1.x in version range

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.configuration-cache=true
 ## Environment Properties
 
 minecraft_version=26.1
-minecraft_version_range=[26.1]
+minecraft_version_range=[26.1,26.2)
 neo_version=26.1.0.1-beta
 
 ## Mod Properties


### PR DESCRIPTION
`neoforge/26.1` was pinned to 26.1 in the metadata, so it didn’t launch on 26.1.2.
I changed the metadata to allow 26.1.x, and it worked without any other changes.

<img width="966" height="620" alt="image" src="https://github.com/user-attachments/assets/e8f8a3fc-3eac-4b34-91b3-72e65d78e51f" />
