### PR TITLE
feat(fabric): add Minecraft 26.2 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1
-loader_version=0.18.4
+minecraft_version=26.2
+loader_version=0.19.3
 loom_version=1.15-SNAPSHOT
 
 # Mod Properties
@@ -17,7 +17,7 @@ maven_group=dev.httxrafa.modflared
 archives_base_name=modflared
 
 # Dependencies
-fabric_version=0.144.3+26.1
+fabric_version=0.153.0+26.2
 
 # Modrinth Properties
 modrinth_project_id=modflared

--- a/src/main/java/dev/httxrafa/modflared/mixin/client/ConnectScreenRunnableMixin.java
+++ b/src/main/java/dev/httxrafa/modflared/mixin/client/ConnectScreenRunnableMixin.java
@@ -23,7 +23,7 @@ public class ConnectScreenRunnableMixin {
         var status = Modflared.TUNNEL_MANAGER.handleConnect(address);
         Modflared.TUNNEL_MANAGER.prepareConnection(status, connection);
 
-        var currentScreen =  Minecraft.getInstance().screen;
+        var currentScreen = Minecraft.getInstance().gui.screen();
         if (currentScreen instanceof ConnectScreen connectScreen) {
             ((IConnectScreen) connectScreen).setStatus(status);
         }

--- a/src/main/java/dev/httxrafa/modflared/tunnel/manager/TunnelManager.java
+++ b/src/main/java/dev/httxrafa/modflared/tunnel/manager/TunnelManager.java
@@ -231,7 +231,7 @@ public class TunnelManager {
     }
 
     public static void displayErrorToast() {
-        Minecraft.getInstance().getToastManager().addToast(new SystemToast(SystemToast.SystemToastId.PERIODIC_NOTIFICATION, Component.translatable("gui.toast.title.error"), Component.translatable("gui.toast.body.error")));
+        Minecraft.getInstance().gui.toastManager().addToast(new SystemToast(SystemToast.SystemToastId.PERIODIC_NOTIFICATION, Component.translatable("gui.toast.title.error"), Component.translatable("gui.toast.body.error")));
     }
 
 }

--- a/src/main/java/dev/httxrafa/modflared/tunnel/manager/TunnelManager.java
+++ b/src/main/java/dev/httxrafa/modflared/tunnel/manager/TunnelManager.java
@@ -231,7 +231,9 @@ public class TunnelManager {
     }
 
     public static void displayErrorToast() {
-        Minecraft.getInstance().gui.toastManager().addToast(new SystemToast(SystemToast.SystemToastId.PERIODIC_NOTIFICATION, Component.translatable("gui.toast.title.error"), Component.translatable("gui.toast.body.error")));
+        var minecraft = Minecraft.getInstance();
+        if (minecraft == null || minecraft.gui == null) return;
+        minecraft.gui.toastManager().addToast(new SystemToast(SystemToast.SystemToastId.PERIODIC_NOTIFICATION, Component.translatable("gui.toast.title.error"), Component.translatable("gui.toast.body.error")));
     }
 
 }


### PR DESCRIPTION
## Summary

- Bumps \`minecraft_version\` to \`26.2\`, \`fabric-api\` to \`0.153.0+26.2\`, and \`loader_version\` to \`0.19.3\`
- Fixes two Minecraft 26.2 API renames:
  - \`Minecraft.screen\` (field) → \`Minecraft.gui.screen()\` (method on \`Gui\`)
  - \`Minecraft.getToastManager()\` → \`Minecraft.gui.toastManager()\`

## Context

In Minecraft 26.2, the current Screen and ToastManager were moved from direct fields/methods on the \`Minecraft\` class into the new \`Gui\` class (\`Minecraft.gui\`). Without these fixes, the mod crashes on startup with a mixin injection failure.

## Test plan

- [x] Compiles cleanly with \`./gradlew build\`
- [ ] Tested in-game connecting to a server behind a Cloudflare tunnel on Minecraft 26.2 + Fabric Loader 0.19.3